### PR TITLE
Fixed issue with Postgres 10

### DIFF
--- a/django_sql_dashboard/views.py
+++ b/django_sql_dashboard/views.py
@@ -159,7 +159,7 @@ def _dashboard_index(
             )
             select
               information_schema.columns.table_name,
-              array_to_json(array_agg(column_name order by ordinal_position)) as columns
+              array_to_json(array_agg(cast(column_name as text) order by ordinal_position)) as columns
             from
               information_schema.columns
             join


### PR DESCRIPTION
When using Postgres 10 the `information_schema.columns.column_name` needs to be cast as text. Otherwise, an error is generated which states:

```
could not find array type for data type information_schema.sql_identifier
```